### PR TITLE
feat: add hibernate

### DIFF
--- a/files/templates/requirements.yml.j2
+++ b/files/templates/requirements.yml.j2
@@ -39,3 +39,7 @@
 - name: apt
   src: git+https://github.com/Schroeffu/ansible-role-potos_apt.git
   version: 'main'
+
+- name: hibernate
+  src: git+https://github.com/nis65/ansible-role-potos_hibernate.git
+  version: 'develop'


### PR DESCRIPTION
## Description

Need some sudo rules to allow my AMD based Laptop (*HP ProBook 635 Aero G7 (2E9E4EA)*) to properly wake up after 2nd suspend. 

There are lengthy discussion on the web about AMD GPUs not properly waking up after
2nd suspend (yes, the wake up after the first suspend (after a reboot) works flawlessly, 
see e.g. [this bug](https://bugs.launchpad.net/ubuntu/+source/linux-signed-hwe-5.19/+` bug/2008774).

Various, not so appealing options were given that solve the problem for some, for some others not.

I found out by experiments that calling e.g. `/lib/systemd/systemd-sleep suspend` as root (instead of `systemctl suspend` solves the problem for me. This is the much leaner (and probably hardware independent) solution than all others proposed.

## Dependencies

none