### PR TITLE
Revert "feat: add gnome-screensaver"

### DIFF
--- a/vars/potos_apt.yml
+++ b/vars/potos_apt.yml
@@ -4,4 +4,3 @@ potos_apt_packages:
   - firefox
   - apt-file
   - pm-utils
-  - gnome-screensaver


### PR DESCRIPTION
This reverts commit 54cbc213e8a72cc99ab7d777378b7b4fa1164606.

## Description
gnome-screensaver was not needed to implement the "cannot wake up from 2nd suspend".

## Dependencies
none