### PR TITLE
fix: workaround for runtype variable name

### DIFF
--- a/vars/potos_basics.yml
+++ b/vars/potos_basics.yml
@@ -1,0 +1,3 @@
+---
+
+potos_basics_ansible_runtype_var_name: "potos_runtype"


### PR DESCRIPTION
## Description

The template for the ansible pull script in the potos basics role defaults to a variable name defined by the client name: 

~~~

./ansible/roles/basics/vars/main.yml:potos_basics_ansible_runtype_var_name: "{{ potos_basics_client_name | lower }}_runtype"
~~~

However, elsewhere this is not parametrized:

~~~
root@mlc0:/var/lib/mlc# find . -type f | xargs grep potos_runtype
./ansible/molecule/default/converge.yml:        - 'ansible-playbook -e "potos_runtype=daily" /potos/prepare.yml'
./ansible/molecule/default/converge.yml:        - 'ansible-playbook -e "potos_runtype=daily" /potos/playbook.yml'
./ansible/templates/requirements.yml.j2:{% if potos_runtype == 'setup' %}
./ansible/playbook.yml:    potos_runtype: 'daily'
./ansible/specs/files/templates/requirements.yml.j2:{% if potos_runtype == 'setup' %}
./ansible/roles/apt/tasks/apt_package.yml:        potos_runtype == setup
~~~

## Dependencies

none
