### PR TITLE
feat: added mlc profile.d settings

### DIFF
--- a/files/potos_files/etc/profile.d/Z99-mlc-settings.sh
+++ b/files/potos_files/etc/profile.d/Z99-mlc-settings.sh
@@ -1,0 +1,1 @@
+export EDITOR=vi

--- a/vars/potos_files.yml
+++ b/vars/potos_files.yml
@@ -17,3 +17,5 @@ potos_files:
     dest: "/etc/potos_all/mount_smb_sudo/example/usermap"
   - src: "etc/vim/vimrc.local"
     dest: "/etc/vim/vimrc.local"
+  - src: "etc/profile.d/Z99-mlc-settings.sh"
+    dest: "/etc/profile.d/Z99-mlc-settings.sh"


### PR DESCRIPTION
Sets and exports the EDITOR variable in /etc/profile.d/
works both for gnome terminal (and other graphical 
shells) as for ssh login - as long the login shell
honours /etc/profile