### PR TITLE
feat: allow wlan config via polkit

### DIFF
--- a/files/potos_files/etc/polkit-1/localauthority/50-local.d/10-allow-users-wlan-config.pkla
+++ b/files/potos_files/etc/polkit-1/localauthority/50-local.d/10-allow-users-wlan-config.pkla
@@ -1,0 +1,8 @@
+[Allow users to configure a new WLAN connection]
+
+Identity=unix-group:{{ potos_files_allow_group }}
+Action=org.freedesktop.NetworkManager.settings.modify.system
+ResultyAny=no
+ResultInactive=no
+ResultActive=yes
+

--- a/vars/potos_files.yml
+++ b/vars/potos_files.yml
@@ -19,3 +19,7 @@ potos_files:
     dest: "/etc/vim/vimrc.local"
   - src: "etc/profile.d/Z99-mlc-settings.sh"
     dest: "/etc/profile.d/Z99-mlc-settings.sh"
+  - src: "etc/polkit-1/localauthority/50-local.d/10-allow-users-wlan-config.pkla"
+    dest: "/etc/polkit-1/localauthority/50-local.d/10-allow-users-wlan-config.pkla"
+
+potos_files_allow_group: "potos"


### PR DESCRIPTION
## Description

uses the group defined in `potos_files_allow_group` to allow its members
to configure the WLAN via polkit.