### PR TITLE
feat: Add libreoffice de support

### DIFF
--- a/vars/potos_apt.yml
+++ b/vars/potos_apt.yml
@@ -59,6 +59,12 @@ potos_apt_packages:
   - pwgen
   - meld
   - mumble
+  - libreoffice-help-de
+  - libreoffice-l10n-de
+  - hunspell-de-ch-frami
+  - hyphen-de
+  - mythes-de
+  - mythes-de-ch
   - google-earth-pro-stable
   - signal-desktop
   - ansible


### PR DESCRIPTION
## Description

These packages are taken for (swiss) german from the list in `apt show libreoffice` after *You can extend the functionality of LibreOffice by installing these packages*
